### PR TITLE
Manage empty or unset SLACK_WEBHOOK_URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Pro tip: install `fortune` in the same machine where the script runs for major f
 
 All the examples make use of the `$SLACK_WEBHOOK_URL` variable. Set it now:
 ```bash
-$ SLACK_WEBHOOK_URL=<your-webhook-url>
+$ export SLACK_WEBHOOK_URL=<your-webhook-url>
 ```
 
 ## Post a simple message

--- a/slack-post.py
+++ b/slack-post.py
@@ -197,4 +197,7 @@ if __name__ == '__main__':
     args, extra = parser.parse_known_args()
     if args.command:
         args.command = [args.command] + extra
+    if not args.webhook_url:
+        parser.error('Please either set the $SLACK_WEBHOOK_URL variable, or '
+                     'provide a value for the -w parameter')
     main(args)


### PR DESCRIPTION
added a check for missing `-w` and `SLACK_WEBHOOK_URL`, and updated the `README` to include the `export` call (otherwise `os.environ.get()` can't read its value!)
