### PR TITLE
Avoid decoding temporary files if no encoding format is given

### DIFF
--- a/slack-post.py
+++ b/slack-post.py
@@ -45,7 +45,8 @@ def read_and_truncate(f, size=1024, relax=10, encoding='UTF-8'):
         size = filesize
 
     data = f.read(size)
-    data = data.decode(encoding)
+    if encoding:
+        data = data.decode(encoding)
 
     if filesize > size:
         data = '\n'.join([data, '[...{} bytes truncated]'.format(filesize - size)])


### PR DESCRIPTION
Not sure if this is the right way to solve this, but `read_and_truncate` fails for the temporary `stdout` and `stderr` files if the OS doesn't give back an encoding format from `sys.stdout.encoding` (on AWS Lambda, it returns `None`).

Not decoding the file seems to work fine on AWS Lambda, and I think always applying `.decode('UTF-8')` and `.decode()` also worked (probably cause the output was just in the normal ascii range), but not too sure what the OS-portable, py2/3 solution is.
